### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This MCP server provides tools to interact with the Linear API, allowing you to fetch tasks and their associated details.
 
+<a href="https://glama.ai/mcp/servers/@Tyru5/linear-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Tyru5/linear-mcp/badge" alt="Linear Server MCP server" />
+</a>
+
 ## Setup
 
 1. Install dependencies:
@@ -109,3 +113,4 @@ use_mcp_tool
 server_name: linear
 tool_name: get_users
 arguments: {}
+```


### PR DESCRIPTION
This PR adds a badge for the [Linear MCP Server](https://glama.ai/mcp/servers/@Tyru5/linear-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@Tyru5/linear-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@Tyru5/linear-mcp/badge" alt="Linear Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.